### PR TITLE
Modified line 121 to work with OS X 10.9 Mavericks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The app has only been tested on Mac OS 10.6.x
 **If you choose the wrong device as the destination, you can erase important data! Proceed with caution.**
 
 ##Changelog
-2014-07-16: Added sudo to fix permissions issue on Mac OS X 10.9.X Mavericks (0.23)
+2014-07-16: Added sudo to fix permissions issue on Mac OS X 10.9.X Mavericks (0.23)  
 2013-11-04: Added sudo to fix permissions issue on Mac OS 10.9 Mavericks (0.22)  
 2009-09-17: Added option to list devices (0.21)  
 2009-09-16: Added automatic unmounting and mounting of devices, plus more robust determination of source size (0.20)  

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The app has only been tested on Mac OS 10.6.x
 **If you choose the wrong device as the destination, you can erase important data! Proceed with caution.**
 
 ##Changelog
-2014-07-16: Added sudo to fix permissions issue on Mac OS X 10.9.X Mavericks (0.23)  
+2014-07-16: Changed sudo command to fix permissions issue on Mac OS X 10.9.X Mavericks (0.23)  
 2013-11-04: Added sudo to fix permissions issue on Mac OS 10.9 Mavericks (0.22)  
 2009-09-17: Added option to list devices (0.21)  
 2009-09-16: Added automatic unmounting and mounting of devices, plus more robust determination of source size (0.20)  

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The app has only been tested on Mac OS 10.6.x
 **If you choose the wrong device as the destination, you can erase important data! Proceed with caution.**
 
 ##Changelog
+2014-07-16: Added sudo to fix permissions issue on Mac OS X 10.9.X Mavericks (0.23)
 2013-11-04: Added sudo to fix permissions issue on Mac OS 10.9 Mavericks (0.22)  
 2009-09-17: Added option to list devices (0.21)  
 2009-09-16: Added automatic unmounting and mounting of devices, plus more robust determination of source size (0.20)  

--- a/dd-gui.app/Contents/Info.plist
+++ b/dd-gui.app/Contents/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>0.22</string>
+	<string>0.23</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSMainNibFile</key>

--- a/dd-gui.app/Contents/MacOS/ddgui
+++ b/dd-gui.app/Contents/MacOS/ddgui
@@ -118,7 +118,7 @@ then
 fi
 
 sudo touch $of
-sudo dd if=$if | $bar -s $size > $of
+if=$if | sudo sh -c '$bar -s $size > $of'
 
 if [ -b "$of" ]
 then


### PR DESCRIPTION
Since OS X 10.9 Mavericks, dd-gui stopped working with "...line 16: /dev/... : Permission denied" message.
Changing line 121 in ddgui file resolve issue in Mac OS X 10.9.X (tested successfully on OS X 10.9.4).
