### PR TITLE
Modified line 121 to work with OS X 10.9 Mavericks

### DIFF
--- a/dd-gui.app/Contents/MacOS/ddgui
+++ b/dd-gui.app/Contents/MacOS/ddgui
@@ -118,7 +118,7 @@ then
 fi
 
 sudo touch $of
-if=$if | sudo sh -c '$bar -s $size > $of'
+dd if=$if | sudo sh -c '$bar -s $size > $of'
 
 if [ -b "$of" ]
 then


### PR DESCRIPTION
Since OS X 10.9 Mavericks, dd-gui stopped working with "...line 16: /dev/... : Permission denied" message.
Changing line 121 in ddgui file resolve issue in Mac OS X 10.9.X (tested successfully on OS X 10.9.4).
